### PR TITLE
feat: add custom scope to auth

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,7 @@
 AUTH_SECRET=<random string: openssl rand -base64 32>
 AUTH_MICROSOFT_ENTRA_ID_ID=<copy Application (client) ID here>
 AUTH_MICROSOFT_ENTRA_ID_SECRET=<copy generated client secret value here>
+AUTH_MICROSOFT_ENTRA_ID_SCOPE="api://<app-registration-uri>/kontraktsportal"
 
 # Not setting this will default to common
 AUTH_MICROSOFT_ENTRA_ID_ISSUER="https://login.microsoftonline.com/[copy-the-tenant-id-here]/v2.0"

--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@
 # misc
 .DS_Store
 *.pem
+.idea/
 
 # debug
 npm-debug.log*

--- a/src/modules/authentication/auth.ts
+++ b/src/modules/authentication/auth.ts
@@ -7,6 +7,11 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
       clientId: process.env.AUTH_MICROSOFT_ENTRA_ID_ID,
       clientSecret: process.env.AUTH_MICROSOFT_ENTRA_ID_SECRET,
       issuer: process.env.AUTH_MICROSOFT_ENTRA_ID_ISSUER,
+      authorization: {
+        params: {
+          scope: `openid profile email ${process.env.AUTH_MICROSOFT_ENTRA_ID_SCOPE}`
+        }
+      }
     }),
   ],
 });


### PR DESCRIPTION

To verify the JWT on the API side, I needed to use a custom scope and request that scope to get the audience set in the token correctly. Without it the audience was set to a default that I was unable to verify against in the API.

Please let me know if there are simpler ways to achieve what we want without using custom scope.


Related to https://github.com/mrfylke/kontraktsportal-org/issues/32